### PR TITLE
package: add info about `repository`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
     "description": "",
     "publisher": "juvvuj",
     "version": "0.0.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/juvvuj/vscode-whoami.git"
+    },
     "engines": {
         "vscode": "^1.46.0"
     },


### PR DESCRIPTION
The commit adds the `repository` field in the `package.json` in order to declare the repo url, and
not warn when we perform a `vsce package`.

Signed-off-by: juvvuj <juvvuj@gmail.com>